### PR TITLE
fix: Remove broken repository stats image

### DIFF
--- a/profile/readme.md
+++ b/profile/readme.md
@@ -7,5 +7,3 @@
 
 [Flagsmith](https://flagsmith.com/) is an open source, fully featured, Feature Flag and Remote Config service. Use
 our hosted API, deploy to your own private cloud, or run on-premise.
-
-![Flagsmith Repository Stats](https://repobeats.axiom.co/api/embed/2e7eb080f3d3a65c7f2ea7d61f25f6191d538c75.svg "Flagsmith Repository Stats")


### PR DESCRIPTION
Removed broken repository stats image from readme (context [here](https://flagsmith.slack.com/archives/C088Z3AMX8U/p1782503823009449))